### PR TITLE
dx-dave: Fix to "out of scope" error

### DIFF
--- a/examples/nunchuck_basic_click/nunchuck_basic_click.ino
+++ b/examples/nunchuck_basic_click/nunchuck_basic_click.ino
@@ -7,6 +7,9 @@
 #include <Wire.h>
 #include <WiiChuck.h>
 
+bool c_update();
+bool z_update();
+
 // Create the nunchuck object
 // c_update and z_update are the button update functions. OSSex/OneButton normally works
 // only with physical buttons (something that is measurably high or low on a digital


### PR DESCRIPTION
ERROR encountered validating nunchuck_basic_click:

Arduino: 1.6.7 (Mac OS X), Board: "LilyPad Arduino USB"

nunchuck_basic_click:14: error: 'c_update' was not declared in this scope
 WiiChuck nunchuck = WiiChuck(c_update, z_update);
                              ^
nunchuck_basic_click:14: error: 'z_update' was not declared in this scope
 WiiChuck nunchuck = WiiChuck(c_update, z_update);
                                        ^
exit status 1
'c_update' was not declared in this scope

  This report would have more information with
  "Show verbose output during compilation"
  enabled in File > Preferences.
