### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,14 +1,14 @@
 OSSex	KEYWORD1
 Toy	KEYWORD1
-WiiChuck  KEYWORD1
+WiiChuck	KEYWORD1
 setOutput	KEYWORD2
 setLED	KEYWORD2
 setID	KEYWORD2
 runPattern	KEYWORD2
 runShortPattern	KEYWORD2
 cyclePattern	KEYWORD2
-nextPattern KEYWORD2
-previousPattern KEYWORD2
+nextPattern	KEYWORD2
+previousPattern	KEYWORD2
 addPattern	KEYWORD2
 getPattern	KEYWORD2
 getInput	KEYWORD2
@@ -18,7 +18,7 @@ attachLongPressStart	KEYWORD2
 attachLongPressStop	KEYWORD2
 attachDuringLongPress	KEYWORD2
 setPowerScaleFactor	KEYWORD2
-getPowerScaleFactor KEYWORD2
+getPowerScaleFactor	KEYWORD2
 setPowerScaleStep	KEYWORD2
 setTimeScaleFactor	KEYWORD2
 getTimeScaleFactor	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords